### PR TITLE
Fix tokenizer options to allow users to specify arbitary filters.

### DIFF
--- a/analysis/lang/ja/analyzer.go
+++ b/analysis/lang/ja/analyzer.go
@@ -12,7 +12,7 @@ func Analyzer() *analysis.Analyzer {
 		CharFilters: []analysis.CharFilter{
 			NewUnicodeNormalizeCharFilter(norm.NFKC),
 		},
-		Tokenizer: NewJapaneseTokenizer(StopTagsFilter(), BaseFormFilter()),
+		Tokenizer: NewJapaneseTokenizer(DefaultStopTagsFilter(), DefaultBaseFormFilter()),
 		TokenFilters: []analysis.TokenFilter{
 			token.NewLowerCaseFilter(),
 			NewStopWordsFilter(),

--- a/analysis/lang/ja/tokenizer.go
+++ b/analysis/lang/ja/tokenizer.go
@@ -29,22 +29,34 @@ var DefaultInflected = filter.NewPOSFilter(
 // TokenizerOption represents an option of the japanese tokenizer.
 type TokenizerOption func(t *JapaneseTokenizer)
 
+// DefaultStopTagsFilter returns a default tags filter option.
+// See the StopTags function.
+func DefaultStopTagsFilter() TokenizerOption {
+	tags := StopTags()
+	ps := make([]filter.POS, 0, len(tags))
+	for k := range tags {
+		ps = append(ps, strings.Split(k, "-"))
+	}
+	return StopTagsFilter(filter.NewPOSFilter(ps...))
+}
+
 // StopTagsFilter returns a stop tags filter option.
-func StopTagsFilter() TokenizerOption {
+func StopTagsFilter(f *filter.POSFilter) TokenizerOption {
 	return func(t *JapaneseTokenizer) {
-		tags := StopTags()
-		ps := make([]filter.POS, 0, len(tags))
-		for k := range tags {
-			ps = append(ps, strings.Split(k, "-"))
-		}
-		t.stopTagFilter = filter.NewPOSFilter(ps...)
+		t.stopTagFilter = f
 	}
 }
 
+// DefaultBaseFormFilter returns a default base form filter option.
+// See DefaultInflected.
+func DefaultBaseFormFilter() TokenizerOption {
+	return BaseFormFilter(DefaultInflected)
+}
+
 // BaseFormFilter returns an base form filter option.
-func BaseFormFilter() TokenizerOption {
+func BaseFormFilter(f *filter.POSFilter) TokenizerOption {
 	return func(t *JapaneseTokenizer) {
-		t.baseFormFilter = DefaultInflected
+		t.baseFormFilter = f
 	}
 }
 

--- a/analysis/lang/ja/tokenizer_test.go
+++ b/analysis/lang/ja/tokenizer_test.go
@@ -114,8 +114,8 @@ func TestJapaneseTokenizer_Tokenize(t *testing.T) {
 			name:  "文分割・フィルターあり",
 			input: []byte("私は鰻。ねこはいます。"),
 			opts: []TokenizerOption{
-				StopTagsFilter(),
-				BaseFormFilter(),
+				DefaultStopTagsFilter(),
+				DefaultBaseFormFilter(),
 			},
 			want: analysis.TokenStream{
 				{
@@ -165,8 +165,8 @@ func TestJapaneseTokenizer_Tokenize(t *testing.T) {
 			name:  "文ごとDropされるとき",
 			input: []byte("私は鰻。は。ねこはいます。"),
 			opts: []TokenizerOption{
-				StopTagsFilter(),
-				BaseFormFilter(),
+				DefaultStopTagsFilter(),
+				DefaultBaseFormFilter(),
 			},
 			want: analysis.TokenStream{
 				{


### PR DESCRIPTION
**BREAKING CHANGE**

The tokenizer options will be modified to allow you to specify arbitrary filters. The previous default filter options will be renamed as follows:

* StopTagsFilter() --> DefaultStopTagsFilter()
* BaseFormFilter() --> DefaultBaseFormFilter()
